### PR TITLE
Editing the refs prop and hash styling

### DIFF
--- a/my-app-new/src/components/Vehicle/index.js
+++ b/my-app-new/src/components/Vehicle/index.js
@@ -37,22 +37,23 @@ const defaultOptionYear = {
 class Vehicle extends Component {
     constructor(props){
         super(props);
-        this.focusModelSelection = this.focusModelSelection.bind(this);        
+        this.focusTextInput = this.focusTextInput.bind(this);
         this.state = {
           makeDisabled: true,
           modelDisabled: true,
           yearValue: '',          
           makeValue: '',
           modelValue: '',
-          //buttonDisabled: true,
+
         };
       }
 
 
-      focusModelSelection() {
-        console.log("Focus function is running")
-        this.ModelSelection.focus();                
-        
+
+
+      focusTextInput() {
+        this.textInput.focus();
+
       }
 
 
@@ -66,6 +67,7 @@ class Vehicle extends Component {
         this.setState({ modelDisabled: true });
         this.setState({ makeDisabled: false });
         this.setState({ buttonDisabled: false});
+        this.textInput.focus();  
         
       }
 
@@ -76,14 +78,15 @@ class Vehicle extends Component {
         this.setState({ makeValue: value });
         this.setState({modelValue: ''});
         this.setState({ modelDisabled: false });
-        //this.ModelSelection.focus();                
-    }
+
+      }
 
       enableComplete = (event) => {
         console.log(event.value);
         const value = event.value;                
         this.setState({ modelValue: value });
-        }
+      
+      }
 
 
 
@@ -96,6 +99,7 @@ class Vehicle extends Component {
                 enableMake,
                 enableModel,
                 focusModelSelection,
+                focusTextInput,
             } = this;
 
             const {
@@ -128,7 +132,8 @@ class Vehicle extends Component {
 
             <div className="flex-container">
             <Autocomplete
-            inputclassName="flex-item-1"                      
+            inputclassName="flex-item-1"
+            inputRef={(input) => {this.textInput = input; }}
             //label="Makes"
             placeholder="Make"
             value={ this.state.makeValue }
@@ -138,6 +143,7 @@ class Vehicle extends Component {
             disabled={this.state.makeDisabled}
             />
 
+            <input className="flex-item-3" placeholder="/" disabled="true"/>
 
             <Autocomplete
             inputclassName="flex-item-2"
@@ -146,7 +152,6 @@ class Vehicle extends Component {
             value={ this.state.modelValue }
             minFilterValueLength={ 3 }
             suggestions={ models }
-            //ref={(input) => {this.ModelSelection = input; }}            
             disabled={this.state.modelDisabled}
             onClickSuggestion={(event) => {this.enableComplete(event)}}
 
@@ -159,8 +164,7 @@ class Vehicle extends Component {
 
             <Button className="btn" text="Add" disabled={this.state.buttonDisabled}/>
 
-            {/* <input type="text" ref={(input) => {this.ModelSelection = input; }} /> */}
-            {/* <input type="button" onClick={this.focusModelSelection} /> */}
+           {/*  <input type="text" ref={(input) => {this.textInput = input; }} /> */}
 
 
 

--- a/my-app-new/src/components/Vehicle/style.css
+++ b/my-app-new/src/components/Vehicle/style.css
@@ -5,15 +5,6 @@
 
 }
 
-/* 
-
-::placeholder {
-
-  color: #CCC;
-
-}
-
-*/
 
 #Break {
 
@@ -53,6 +44,7 @@
     text-overflow: ellipsis;
     width: 82%;
     z-index: 50;
+
 }
 
 
@@ -78,6 +70,27 @@
   }
 
 
+  .flex-item-3{
+    
+        border-width: 1px 0 1px 0; 
+        /*border-radius: 0 0 0 0;*/
+        padding: 20px;
+        font-size: 0.9em;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+        background-color: transparent;
+        /*border-bottom: 0.0625rem solid #6B7789;*/
+        display: block;
+        color: #222;
+        font-family: "Allstate Sans", Arial, Helvectica, sans-serif;
+        position: relative;
+        text-overflow: ellipsis;
+        width: 22%;
+        z-index: 50;
+    
+    }
+
 /* 
 
 .flex-item-1:disabled, .flex-item-2:disabled {
@@ -96,8 +109,6 @@ color: #efefee;
 }
 
 
-
-
 .c-autocomplete__clear.is-active {
 
     display: none;
@@ -105,10 +116,14 @@ color: #efefee;
 }
 
 .c-dropdown {
+
     display: flex;
     flex-direction: column;
     position: relative;
-    margin: 20px 0; }
+    margin: 20px 0; 
+
+  }
+    
     .c-dropdown select {
       background-color: #fff;
       padding: 20px;

--- a/my-app-new/src/components/autocomplete/index.js
+++ b/my-app-new/src/components/autocomplete/index.js
@@ -609,6 +609,7 @@ export default class Autocomplete extends React.Component {
       suggestionListID,
       _onClickSuggestion,
       _onInput,
+      inputRef,
       _onKeyDown,
       _clearAutocomplete,
     } = this;
@@ -622,12 +623,14 @@ export default class Autocomplete extends React.Component {
           { ...other }
           _formValidateOnBlur={false}
           id={ id }
-          ref={ (formField) => {
+         /* ref={ (formField) => {
             if (!formField) {
               return;
             }
             this.formField = formField.formField;
-          } }
+          } }  */
+
+          ref={ inputRef }
           role="combobox"
           aria-expanded={ isActive ? 'true' : 'false' }
           aria-autocomplete="both"


### PR DESCRIPTION
- Changing ref to a prop to try and focus on the autocomplete components rather than an input 

- Placeholder input box added to act as the forward slash in-between the make and model autocompletes, third flex item essentially 

-  focus function and 'this' binding issue fixed, can be applied to the input now 